### PR TITLE
fix: preserve extension-registered providers on model registry refresh

### DIFF
--- a/electron/pi/sidecar.ts
+++ b/electron/pi/sidecar.ts
@@ -99,7 +99,12 @@ function getModelRegistry() {
 }
 
 function invalidateModelRegistry(): void {
-  _modelRegistry = null
+  if (_modelRegistry) {
+    // Refresh the existing instance so extension-registered providers
+    // (registered during createAgentSession → bindCore) are preserved.
+    // Nulling + recreating would lose them since extensions only run once.
+    _modelRegistry.refresh()
+  }
 }
 
 function outputLine(level: 'info' | 'warn' | 'error', text: string): void {


### PR DESCRIPTION
## Problem

When a new session is created, extensions register their providers during  → . The previous invalidation path in  set , which discarded those extension-registered providers.

## Fix

Instead of nulling the registry, call  on the existing instance so extension-registered providers survive across session replacements.

## Changes

- : Call  instead of setting 