### PR TITLE
fix: Settings fields blank — FieldControl not reactive to prop changes

### DIFF
--- a/src/components/customizations/SettingRow.tsx
+++ b/src/components/customizations/SettingRow.tsx
@@ -60,17 +60,17 @@ function FieldControl(props: {
   onChange: (v: unknown) => void
 }) {
   if (props.field.type === 'boolean') {
-    const on =
+    const on = () =>
       typeof props.value === 'boolean'
         ? props.value
         : ((props.field.default as boolean | undefined) ?? false)
     return (
       <button
         type="button"
-        class={`osp-toggle${on ? ' is-on' : ''}`}
-        onClick={() => props.onChange(!on)}
+        class={`osp-toggle${on() ? ' is-on' : ''}`}
+        onClick={() => props.onChange(!on())}
         role="switch"
-        aria-checked={on}
+        aria-checked={on()}
         aria-label={props.field.label}
       >
         <span class="osp-toggle-thumb" />
@@ -79,14 +79,14 @@ function FieldControl(props: {
   }
 
   if (props.field.type === 'select') {
-    const val =
+    const val = () =>
       props.value !== undefined && props.value !== null && props.value !== ''
         ? String(props.value)
         : ''
     return (
       <select
         class="osp-select"
-        value={val}
+        value={val()}
         onChange={(e) =>
           props.onChange(e.currentTarget.value === '' ? undefined : e.currentTarget.value)
         }
@@ -99,7 +99,7 @@ function FieldControl(props: {
   }
 
   if (props.field.type === 'number') {
-    const num =
+    const num = () =>
       props.value !== undefined && props.value !== null
         ? Number(props.value)
         : ((props.field.default as number | undefined) ?? 0)
@@ -107,7 +107,7 @@ function FieldControl(props: {
       <input
         class="osp-input osp-input-num"
         type="number"
-        value={num}
+        value={num()}
         min={props.field.min}
         max={props.field.max}
         step={props.field.step ?? 1}
@@ -119,7 +119,7 @@ function FieldControl(props: {
   }
 
   if (props.field.type === 'string') {
-    const str =
+    const str = () =>
       props.value !== undefined && props.value !== null && props.value !== ''
         ? String(props.value)
         : ''
@@ -127,7 +127,7 @@ function FieldControl(props: {
       <input
         class="osp-input"
         type="text"
-        value={str}
+        value={str()}
         placeholder={
           props.field.placeholder ?? (props.field.default ? String(props.field.default) : undefined)
         }


### PR DESCRIPTION
## Problem

All Settings fields (Model & Thinking, Compaction, Retry, etc.) show blank/empty values even though `settings.json` contains valid data. IPC returns correct data (`window.openpi.getSettings()` confirms `global.defaultProvider`, `global.defaultModel`, `global.defaultThinkingLevel` all populated).

## Root Cause

SolidJS component body functions run **once** at creation. `FieldControl` computed display values as plain variables:

```ts
// BEFORE — evaluated once with initial props.value (undefined), never updates
const str = props.value !== undefined && props.value !== null && props.value !== ''
  ? String(props.value)
  : ''
return <input value={str} />
```

When the async IPC call completes and `setLocal()` updates the signal, `props.value` changes but `str` stays stale because the dependency on `props.value` is outside the JSX return's tracking scope.

## Fix

Convert plain variables to getter functions so they re-evaluate inside the JSX tracking scope:

```ts
// AFTER — re-evaluates when props.value changes
const str = () =>
  props.value !== undefined && props.value !== null && props.value !== ''
    ? String(props.value)
    : ''
return <input value={str()} />
```

Fixed all four affected handlers:

| Type | Variable | Issue |
|------|----------|-------|
| `string` | `str` | Text inputs blank |
| `select` | `val` | Dropdowns show empty |
| `number` | `num` | Number inputs show 0 |
| `boolean` | `on` | Toggle state stale + click sends wrong value |

The `select` handler's dropdown and the `boolean` toggle's `onClick` closure were particularly affected — toggling a boolean would send the stale initial value instead of the current state.