### PR TITLE
fix(git): use a template literal in the GIT_DIFF no-cwd warning

### DIFF
--- a/electron/git/ipc.ts
+++ b/electron/git/ipc.ts
@@ -180,7 +180,7 @@ export function registerGitIpc(deps: GitIpcDeps): void {
     const parsed = gitDiffRequestSchema.parse(raw)
     const cwd = resolveGitCwd(deps) ?? parsed.cwd
     if (!cwd) {
-      console.warn('[openpi:git] GIT_DIFF no cwd (path=${parsed.path})')
+      console.warn(`[openpi:git] GIT_DIFF no cwd (path=${parsed.path})`)
       return null
     }
     const git = await deps.getGitHost()


### PR DESCRIPTION
The `GIT_DIFF` no-cwd warning in `electron/git/ipc.ts` is single-quoted, so it logs the literal text `${parsed.path}` instead of interpolating the path:

```ts
console.warn('[openpi:git] GIT_DIFF no cwd (path=${parsed.path})')
```

That branch only runs once `resolveGitCwd()` has already failed and `parsed.cwd` is empty — the moment the path is most worth having in the log. One character class change, no behaviour change beyond the log output.

Biome already flags it as `lint/suspicious/noTemplateCurlyInString`; this clears that warning.

### Verified

- `npx biome check electron/git/ipc.ts` — the `noTemplateCurlyInString` warning is gone (the pre-existing `sawOldPath` unused-variable warning in the same file is untouched, see below).
- `npx biome check --diagnostic-level=error` — clean across the tree, before and after.
- Committed with the `.githooks` pre-commit hook enabled.

### Not verified

I did not run the test suite for this. My local checkout of this repo has `@earendil-works/pi-coding-agent` at 0.82.1 installed for unrelated work, so `npm test`/`npm run typecheck` here would be exercising a different SDK than this branch's `package.json` pins, and the result would be misleading rather than reassuring. The change is a quoting fix in a `console.warn` argument, with no other code path touched.

### Deliberately left alone

`electron/git/ipc.ts:81` has a second Biome warning: `sawOldPath` is assigned in three places but never read, while its sibling `sawNewPath` is read. Biome's suggested fix is to rename it `_sawOldPath`, but that would paper over what might be an incomplete validation rather than fix it — whether the old-path check was meant to be enforced is a call for someone who knows the intent of `validateHunkPatch()`. Happy to open a separate issue or PR if you'd like it addressed either way; it seemed wrong to bundle a judgement call into a one-line quoting fix.
